### PR TITLE
Bump GitHub Actions dependencies

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Deno
         uses: denoland/setup-deno@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
         run: git config --global core.autocrlf false
 
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Deno
         uses: denoland/setup-deno@v2
@@ -79,7 +79,7 @@ jobs:
         run: git config --global core.autocrlf false
 
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -119,9 +119,9 @@ jobs:
         run: git config --global core.autocrlf false
 
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bumps GitHub Actions dependencies in the CI and publish workflows.

## Changes

| Action | Before | After | Latest release |
| --- | --- | --- | --- |
| `actions/checkout` | `v4` | `v7` | v7.0.0 |
| `actions/setup-node` | `v4` | `v6` | v6.4.0 |
| `denoland/setup-deno` | `v2` | `v2` | v2.0.5 (already on latest major) |
| `oven-sh/setup-bun` | `v2` | `v2` | v2.2.0 (already on latest major) |

## Notes

- `actions/checkout` v7 and `actions/setup-node` v6 run on the Node.js 24 runtime and require GitHub-hosted runners v2.327.1+.
- `denoland/setup-deno@v2` and `oven-sh/setup-bun@v2` already track the latest v2 releases via their major version tags.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83eb9638-bf6c-48d6-be0b-efcc7ec89b55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83eb9638-bf6c-48d6-be0b-efcc7ec89b55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

