### PR TITLE
feat(logger): add benchmark script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,17 +44,20 @@ jobs:
         with:
           deno-version: canary
 
+      - name: Set up Just
+        uses: extractions/setup-just@v2
+
       - name: Deno version
         run: deno --version
 
       - name: Install dependencies
         run: deno install --vendor
 
-      - name: Format & Check
-        run: deno run check
+      - name: Lint
+        run: just lint
 
       - name: Test
-        run: deno run test
+        run: just test
 
       - name: Publish dry run
         run: deno publish --dry-run

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ It is tested against Bun, Deno, and Node.js runtimes. Published on [jsr.io (`@fr
 Use `deno fmt`, `deno lint`, and `deno run -A @biomejs/biome lint` to check the code.
 
 ```bash
-deno task check
+just lint
 ```
 
 See [_Writing documentation_](https://jsr.io/docs/writing-docs) for details about writing JSDoc.
@@ -32,7 +32,7 @@ See [_Writing documentation_](https://jsr.io/docs/writing-docs) for details abou
 This uses [`@cross/test`](https://jsr.io/@cross/test) and [`sinon`](https://sinonjs.org) to run the tests.
 
 ```bash
-deno task test
+just test
 ```
 
 For Node.js and Bun, install dependencies with [Nub](https://nubjs.com/docs) and run tests:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It is tested against Bun, Deno, and Node.js runtimes. Published on [jsr.io (`@fr
 
 ## Lint
 
-Use `deno fmt`, `deno lint`, and `deno run -A @biomejs/biome lint` to check the code.
+Uses Biome to check the code.
 
 ```bash
 just lint

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -16,9 +16,7 @@
 	},
 	"tasks": {
 		"bench-logger": "deno run -A logger/benchmark.ts",
-		"check": "deno fmt --check && deno lint && deno run -A @biomejs/biome lint",
 		"dry-run": "deno publish --dry-run",
-		"test": "deno test --allow-sys --allow-env --clean --coverage",
 		"update": "deno outdated --update --latest --recursive"
 	},
 	"lint": {

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -15,6 +15,7 @@
 		"exclude": ["**/*.md", "**/*.yml", "**/*.yaml"]
 	},
 	"tasks": {
+		"bench-logger": "deno run -A logger/benchmark.ts",
 		"check": "deno fmt --check && deno lint && deno run -A @biomejs/biome lint",
 		"dry-run": "deno publish --dry-run",
 		"test": "deno test --allow-sys --allow-env --clean --coverage",

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -7,29 +7,10 @@
 		"noUncheckedIndexedAccess": true
 	},
 	"exclude": [".git", ".github", "vendor"],
-	"fmt": {
-		"useTabs": true,
-		"lineWidth": 120,
-		"semiColons": false,
-		"singleQuote": true,
-		"exclude": ["**/*.md", "**/*.yml", "**/*.yaml"]
-	},
 	"tasks": {
 		"bench-logger": "deno run -A logger/benchmark.ts",
 		"dry-run": "deno publish --dry-run",
 		"update": "deno outdated --update --latest --recursive"
-	},
-	"lint": {
-		"rules": {
-			"include": [
-				"camelcase",
-				"no-sync-fn-in-async-fn",
-				"single-var-declarator",
-				"verbatim-module-syntax",
-				"no-console"
-			]
-		},
-		"exclude": ["**/*.md", "**/*.yml", "**/*.yaml"]
 	},
 	"workspace": ["./check-required-env", "./crypto", "./dates", "./logger"],
 	"imports": {

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -36,7 +36,7 @@
 	"workspace": ["./check-required-env", "./crypto", "./dates", "./logger"],
 	"imports": {
 		"@biomejs/biome": "npm:@biomejs/biome@^2.5.3",
-		"@types/node": "npm:@types/node@^26.0.1",
+		"@types/node": "npm:@types/node@^26.1.1",
 		"@cross/test": "jsr:@cross/test@^0.0.14",
 		"@std/assert": "jsr:@std/assert@^1.0.19",
 		"@types/sinon": "npm:@types/sinon@^22.0.0",

--- a/deno.lock
+++ b/deno.lock
@@ -15,8 +15,7 @@
     "npm:@jsr/std__fmt@^1.0.10": "1.0.10",
     "npm:@types/luxon@^3.4.2": "3.7.2",
     "npm:@types/luxon@^3.7.2": "3.7.2",
-    "npm:@types/node@*": "26.0.1",
-    "npm:@types/node@^26.0.1": "26.0.1",
+    "npm:@types/node@^26.1.1": "26.1.1",
     "npm:@types/sinon@22": "22.0.0",
     "npm:luxon@^3.7.2": "3.7.2",
     "npm:sinon@22": "22.0.0",
@@ -317,8 +316,8 @@
     "@types/luxon@3.7.2": {
       "integrity": "sha512-gW+Oib+vUtGJBtNC8V9Reww0oIpusw+4m81uncg9REGZAJfqOQHfo/nkabnc7w0QReXyPqjrbWMJk6NuAkiX3Q=="
     },
-    "@types/node@26.0.1": {
-      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
+    "@types/node@26.1.1": {
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dependencies": [
         "undici-types"
       ]
@@ -589,7 +588,7 @@
       "jsr:@cross/test@^0.0.14",
       "jsr:@std/assert@^1.0.19",
       "npm:@biomejs/biome@^2.5.3",
-      "npm:@types/node@^26.0.1",
+      "npm:@types/node@^26.1.1",
       "npm:@types/sinon@22",
       "npm:sinon@22"
     ],

--- a/justfile
+++ b/justfile
@@ -12,8 +12,6 @@ bench-logger:
 	deno run bench-logger
 
 lint:
-	deno fmt --check
-	deno lint
 	deno run -A @biomejs/biome lint
 
 format:

--- a/justfile
+++ b/justfile
@@ -7,3 +7,6 @@ update:
 
 test:
 	deno run test
+
+bench-logger:
+	deno run bench-logger

--- a/justfile
+++ b/justfile
@@ -6,7 +6,16 @@ update:
 	deno run update
 
 test:
-	deno run test
+	deno test --allow-sys --allow-env --clean --coverage
 
 bench-logger:
 	deno run bench-logger
+
+lint:
+	deno fmt --check
+	deno lint
+	deno run -A @biomejs/biome lint
+
+format:
+	nubx biome lint --write
+	nubx biome format --write

--- a/logger/benchmark.ts
+++ b/logger/benchmark.ts
@@ -1,0 +1,110 @@
+/**
+ * Benchmark @frytg/logger against a plain Winston JSON logger.
+ *
+ * Usage: deno run -A logger/benchmark.ts [iterations]
+ */
+
+import process from 'node:process'
+import { config, createLogger, format, transports } from 'winston'
+
+const DEFAULT_ITERATIONS = 50_000
+const WARMUP_ITERATIONS = 1_000
+
+process.env.STAGE = 'prod'
+process.env.IS_LOCAL = 'false'
+process.env.SERVICE_NAME = 'benchmark-service'
+process.env.SERVICE_VERSION = '0.0.0'
+
+const { detectProcessVersion, logger: frytgLogger } = await import('./logger.ts')
+
+type BenchCase = {
+	name: string
+	run: () => void
+}
+
+/**
+ * Silence stdout writes so benchmark timing is not dominated by terminal I/O.
+ *
+ * @returns restore function
+ */
+const silenceStdout = (): () => void => {
+	const originalWrite = process.stdout.write.bind(process.stdout)
+	process.stdout.write = (() => true) as typeof process.stdout.write
+	return () => {
+		process.stdout.write = originalWrite
+	}
+}
+
+/**
+ * Run a benchmark case with warmup and return ops/sec.
+ *
+ * @param benchCase - case name and run function
+ * @param iterations - measured iterations
+ * @returns operations per second
+ */
+const runBenchCase = (benchCase: BenchCase, iterations: number): number => {
+	const restoreStdout = silenceStdout()
+	try {
+		for (let i = 0; i < WARMUP_ITERATIONS; i++) benchCase.run()
+
+		const start = performance.now()
+		for (let i = 0; i < iterations; i++) benchCase.run()
+		const durationMs = performance.now() - start
+
+		return (iterations / durationMs) * 1000
+	} finally {
+		restoreStdout()
+	}
+}
+
+/**
+ * Print a formatted line to stdout.
+ *
+ * @param line - text to print
+ */
+const printLine = (line: string): void => {
+	process.stdout.write(`${line}\n`)
+}
+
+const plainLogger = createLogger({
+	level: 'info',
+	levels: config.syslog.levels,
+	exitOnError: false,
+	format: format.combine(format.timestamp(), format.json()),
+	transports: [new transports.Console()],
+})
+
+const logPayload = {
+	message: 'benchmark message',
+	source: 'logger/benchmark.ts',
+	data: { requestId: 'abc-123', userId: 42, nested: { ok: true } },
+}
+
+const iterations = Number.parseInt(Deno.args[0] ?? `${DEFAULT_ITERATIONS}`, 10)
+
+const cases: BenchCase[] = [
+	{
+		name: 'winston (json)',
+		run: () => plainLogger.info(logPayload),
+	},
+	{
+		name: '@frytg/logger (json)',
+		run: () => frytgLogger.info(logPayload.message, logPayload),
+	},
+]
+
+printLine(`Logger benchmark (${iterations.toLocaleString()} iterations, runtime: ${detectProcessVersion()})`)
+printLine('')
+
+const results = cases.map((benchCase) => ({
+	name: benchCase.name,
+	ops: runBenchCase(benchCase, iterations),
+}))
+
+const baselineOps = results[0].ops
+
+for (const result of results) {
+	const relative = result.ops / baselineOps
+	const relativeLabel = result === results[0] ? 'baseline' : `${(relative * 100).toFixed(1)}%`
+	printLine(`${result.name.padEnd(24)} ${result.ops.toFixed(0).padStart(10)} ops/s  (${relativeLabel})`)
+}

--- a/logger/benchmark.ts
+++ b/logger/benchmark.ts
@@ -27,7 +27,7 @@ type BenchCase = {
  *
  * @returns restore function
  */
-const silenceStdout = (): () => void => {
+const silenceStdout = (): (() => void) => {
 	const originalWrite = process.stdout.write.bind(process.stdout)
 	process.stdout.write = (() => true) as typeof process.stdout.write
 	return () => {

--- a/logger/deno.jsonc
+++ b/logger/deno.jsonc
@@ -7,6 +7,6 @@
 		"winston": "npm:winston@^3.19.0"
 	},
 	"publish": {
-		"exclude": ["*.test.ts"]
+		"exclude": ["*.test.ts", "benchmark.ts"]
 	}
 }

--- a/logger/logger-browser.ts
+++ b/logger/logger-browser.ts
@@ -45,7 +45,7 @@ const isDev = (): boolean => {
  *
  * @returns {SyslogLevel} The configured minimum log level.
  */
-const resolveMinLevel = (): SyslogLevel => isDev() ? 'debug' : 'info'
+const resolveMinLevel = (): SyslogLevel => (isDev() ? 'debug' : 'info')
 
 /**
  * Select the console method that best matches a syslog level.
@@ -66,7 +66,7 @@ const consoleMethodForLevel = (level: SyslogLevel): 'debug' | 'error' | 'log' | 
  * @param {LogEvent} event - The structured log event.
  * @returns {string} Serialized log output.
  */
-const formatLogEvent = (event: LogEvent): string => isDev() ? JSON.stringify(event, null, 4) : JSON.stringify(event)
+const formatLogEvent = (event: LogEvent): string => (isDev() ? JSON.stringify(event, null, 4) : JSON.stringify(event))
 
 /**
  * Create a browser-safe logger with syslog levels and structured JSON output.

--- a/logger/logger.ts
+++ b/logger/logger.ts
@@ -53,7 +53,8 @@ const processRuntime = detectProcessVersion()
 
 // Add global context to log events
 const convertGlobals = format((event) => {
-	event.host = process.env.K_REVISION ||
+	event.host =
+		process.env.K_REVISION ||
 		process.env.AWS_LAMBDA_FUNCTION_NAME ||
 		process.env.FLY_MACHINE_ID ||
 		process.env.DENO_DEPLOYMENT_ID ||
@@ -61,8 +62,8 @@ const convertGlobals = format((event) => {
 	event.serviceName = process.env.SERVICE_NAME || process.env.K_SERVICE || process.env.FLY_APP_NAME || null
 	event.stage = process.env.STAGE || process.env.NODE_ENV || null
 	event.version = process.env.SERVICE_VERSION || process.env.npm_package_version
-	event.region = process.env.REGION || process.env.AWS_REGION || process.env.FLY_REGION || process.env.DENO_REGION ||
-		null
+	event.region =
+		process.env.REGION || process.env.AWS_REGION || process.env.FLY_REGION || process.env.DENO_REGION || null
 	event.runtime = processRuntime
 	return event
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Adds a standalone logger benchmark script that compares `@frytg/logger` against a plain Winston JSON logger.

- New `logger/benchmark.ts` script with warmup, stdout silencing during measurement, and ops/s reporting
- `deno run bench-logger` task and `just bench-logger` recipe
- Excludes `benchmark.ts` from JSR publish

## Why

Closes #16. Provides a quick way to measure the overhead of the `@frytg/logger` wrapper (global context injection, error formatting) relative to raw Winston.

## How to test

```bash
deno install --vendor
deno run check
deno run test
deno run bench-logger
```

Optional: pass a custom iteration count, e.g. `deno run bench-logger 10000`.

## Sample output

```
Logger benchmark (50,000 iterations, runtime: deno-2.9.2)

winston (json)               328074 ops/s  (baseline)
@frytg/logger (json)         101797 ops/s  (31.0%)
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-636f4629-04ab-404a-9705-d1105028c84c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-636f4629-04ab-404a-9705-d1105028c84c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

