### PR TITLE
improve runtime detection

### DIFF
--- a/logger/CHANGELOG.md
+++ b/logger/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Logger Changelog
 
+## 2026-07-13 - 0.0.4
+
+- feat: added Fly.io and Deno Deploy context to log events
+- fix: detect runtime once at module load instead of on every log event
+
 ## 2025-01-10 - 0.0.3
 
 - feat: added AWS Lambda context to log events

--- a/logger/README.md
+++ b/logger/README.md
@@ -34,11 +34,14 @@ The logger accesses and injects several env variables to each log event (envs li
 
 - `host` - the host name (e.g. `my-function`)
   - from env `K_REVISION` - set by Knative such as Google Cloud Run
-  - from env`AWS_LAMBDA_FUNCTION_NAME` - set by AWS Lambda
+  - from env `AWS_LAMBDA_FUNCTION_NAME` - set by AWS Lambda
+  - from env `FLY_MACHINE_ID` - set by [Fly.io Machines](https://fly.io/docs/reference/runtime-environment/)
+  - from env `DENO_DEPLOYMENT_ID` - set by [Deno Deploy](https://docs.deno.com/deploy/manual/environment-variables/)
   - from `os.hostname()` - fallback
 - `serviceName` - the service name (e.g. `my-service`)
   - from env `SERVICE_NAME` - set by your deployment
   - from env `K_SERVICE` - set by Knative such as Google Cloud Run
+  - from env `FLY_APP_NAME` - set by [Fly.io Machines](https://fly.io/docs/reference/runtime-environment/)
 - `stage` - the stage (e.g. `dev`)
   - from env `STAGE` - set by your deployment
   - from env `NODE_ENV` - set by your deployment
@@ -48,9 +51,12 @@ The logger accesses and injects several env variables to each log event (envs li
 - `region` - the region (e.g. `eu-west-1`)
   - from env `REGION` - set by your deployment
   - from env `AWS_REGION` - set by AWS Lambda
+  - from env `FLY_REGION` - set by [Fly.io Machines](https://fly.io/docs/reference/runtime-environment/)
+  - from env `DENO_REGION` - set by [Deno Deploy](https://docs.deno.com/deploy/manual/environment-variables/)
 - `runtime` - the runtime (e.g. `nodejs-20.11.0`)
   - from `process.versions.bun` - set by Bun
   - from `process.versions.deno` - set by Deno
+  - from env `DENO_DEPLOYMENT_ID` with Deno - set by [Deno Deploy](https://docs.deno.com/deploy/manual/environment-variables/) (e.g. `deno-deploy-1.3.2`)
   - from env `AWS_EXECUTION_ENV` - set by AWS Lambda
   - from `process.version` - fallback (usually Node.js)
 

--- a/logger/deno.jsonc
+++ b/logger/deno.jsonc
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://jsr.io/schema/config-file.v1.json",
 	"name": "@frytg/logger",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"exports": "./logger.ts",
 	"imports": {
 		"winston": "npm:winston@^3.19.0"

--- a/logger/logger-context.test.ts
+++ b/logger/logger-context.test.ts
@@ -40,6 +40,68 @@ test('logger - includes global context in log events', () => {
 	envStub.restore()
 })
 
+test('logger - includes fly.io context in log events', () => {
+	// Setup
+	const envStub = sinon.stub(process, 'env').value({
+		FLY_MACHINE_ID: 'machine-abc123',
+		FLY_APP_NAME: 'my-fly-app',
+		FLY_REGION: 'ams',
+		STAGE: 'prod',
+	})
+
+	const writeStub = sinon.stub(process.stdout, 'write')
+	let loggedOutput = ''
+	writeStub.callsFake((str: string | Uint8Array) => {
+		loggedOutput = typeof str === 'string' ? str : new TextDecoder().decode(str)
+		return true
+	})
+
+	// Test
+	logger.info('test message', {
+		source: 'test-source',
+	})
+
+	// Verify
+	const loggedData = JSON.parse(loggedOutput)
+	assertEquals(loggedData.host, 'machine-abc123')
+	assertEquals(loggedData.serviceName, 'my-fly-app')
+	assertEquals(loggedData.region, 'ams')
+
+	// Cleanup
+	writeStub.restore()
+	envStub.restore()
+})
+
+test('logger - includes deno deploy context in log events', () => {
+	// Setup
+	const envStub = sinon.stub(process, 'env').value({
+		DENO_DEPLOYMENT_ID: 'deployment-xyz789',
+		DENO_REGION: 'gcp-europe-west3',
+		STAGE: 'prod',
+	})
+
+	const writeStub = sinon.stub(process.stdout, 'write')
+	let loggedOutput = ''
+	writeStub.callsFake((str: string | Uint8Array) => {
+		loggedOutput = typeof str === 'string' ? str : new TextDecoder().decode(str)
+		return true
+	})
+
+	// Test
+	logger.info('test message', {
+		source: 'test-source',
+	})
+
+	// Verify
+	const loggedData = JSON.parse(loggedOutput)
+	assertEquals(loggedData.host, 'deployment-xyz789')
+	assertEquals(loggedData.region, 'gcp-europe-west3')
+
+	// Cleanup
+	writeStub.restore()
+	envStub.restore()
+})
+
 test('logger - sets debug level correctly', () => {
 	// Test & Verify
 	assertEquals(logger.level, process.env.STAGE === 'dev' ? 'debug' : 'info')

--- a/logger/logger-detect-process-version.test.ts
+++ b/logger/logger-detect-process-version.test.ts
@@ -1,0 +1,11 @@
+import { test } from '@cross/test'
+import { assertEquals } from '@std/assert'
+
+import { detectProcessVersion } from './logger.ts'
+
+test('detectProcessVersion - returns the same value on repeated calls', () => {
+	const first = detectProcessVersion()
+	const second = detectProcessVersion()
+
+	assertEquals(second, first)
+})

--- a/logger/logger.ts
+++ b/logger/logger.ts
@@ -24,26 +24,46 @@ const convertError = format((event) => {
 	return event
 })
 
+let cachedProcessRuntime: string | undefined
+
 /**
  * Detect and return the process version
  *
- * @returns {string} the process version (e.g. `bun-1.1.23`, `deno-1.3.2`, `node-20.11.0`)
+ * @returns {string} the process version (e.g. `bun-1.1.23`, `deno-deploy-1.3.2`, `node-20.11.0`)
  */
 export const detectProcessVersion = (): string => {
-	if (process.versions?.bun) return `bun-${process.versions.bun}`
-	if (process.versions?.deno) return `deno-${process.versions.deno}`
-	if (process.env.AWS_EXECUTION_ENV) return process.env.AWS_EXECUTION_ENV.replace(/_/g, '-')
-	return `nodejs-${process.version}`
+	if (cachedProcessRuntime !== undefined) return cachedProcessRuntime
+
+	if (process.versions?.bun) {
+		cachedProcessRuntime = `bun-${process.versions.bun}`
+	} else if (process.versions?.deno) {
+		cachedProcessRuntime = process.env.DENO_DEPLOYMENT_ID
+			? `deno-deploy-${process.versions.deno}`
+			: `deno-${process.versions.deno}`
+	} else if (process.env.AWS_EXECUTION_ENV) {
+		cachedProcessRuntime = process.env.AWS_EXECUTION_ENV.replace(/_/g, '-')
+	} else {
+		cachedProcessRuntime = `nodejs-${process.version}`
+	}
+
+	return cachedProcessRuntime
 }
+
+const processRuntime = detectProcessVersion()
 
 // Add global context to log events
 const convertGlobals = format((event) => {
-	event.host = process.env.K_REVISION || process.env.AWS_LAMBDA_FUNCTION_NAME || hostName
-	event.serviceName = process.env.SERVICE_NAME || process.env.K_SERVICE || null
+	event.host = process.env.K_REVISION ||
+		process.env.AWS_LAMBDA_FUNCTION_NAME ||
+		process.env.FLY_MACHINE_ID ||
+		process.env.DENO_DEPLOYMENT_ID ||
+		hostName
+	event.serviceName = process.env.SERVICE_NAME || process.env.K_SERVICE || process.env.FLY_APP_NAME || null
 	event.stage = process.env.STAGE || process.env.NODE_ENV || null
 	event.version = process.env.SERVICE_VERSION || process.env.npm_package_version
-	event.region = process.env.REGION || process.env.AWS_REGION || null
-	event.runtime = detectProcessVersion()
+	event.region = process.env.REGION || process.env.AWS_REGION || process.env.FLY_REGION || process.env.DENO_REGION ||
+		null
+	event.runtime = processRuntime
 	return event
 })
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add Fly.io and Deno Deploy cloud environment context to log events, and detect runtime once at module load instead of on every log event.

## Changes

- Cache `detectProcessVersion()` result at module load; log events reuse the cached `processRuntime` value
- Add Fly.io env vars: `FLY_MACHINE_ID` (host), `FLY_APP_NAME` (serviceName), `FLY_REGION` (region)
- Add Deno Deploy env vars: `DENO_DEPLOYMENT_ID` (host), `DENO_REGION` (region), `deno-deploy-*` runtime prefix when on Deno Deploy
- Add tests for fly.io/deno deploy context and runtime caching
- Bump `@frytg/logger` to 0.0.4

## How to test

```bash
deno run check
deno run test
deno publish --dry-run
```

## References

- [Fly.io runtime environment](https://fly.io/docs/reference/runtime-environment/)
- [Deno Deploy environment variables](https://docs.deno.com/deploy/manual/environment-variables/)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-405e14d4-9c89-4791-9cb3-81dda94c5b85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-405e14d4-9c89-4791-9cb3-81dda94c5b85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

