### PR TITLE
feat(logger): add browser entry path for client-side logging

### DIFF
--- a/logger/CHANGELOG.md
+++ b/logger/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Logger Changelog
 
+## 2026-07-13 - 0.1.0
+
+- feat: added `@frytg/logger/browser` entry for frontend apps as a structured `console` replacement
+- feat: shared `syslog-levels` and `serialize-error` modules used by server and browser loggers
+- refactor: browser logger logs caller-provided fields only; dev builds use `import.meta.env.DEV` / `MODE`
+
 ## 2026-07-13 - 0.0.4
 
 - feat: added Fly.io and Deno Deploy context to log events

--- a/logger/README.md
+++ b/logger/README.md
@@ -23,26 +23,26 @@ import logger from '@frytg/logger';
 
 ### Browser
 
-Use the dedicated browser entry. It avoids Node built-ins and Winston, outputs structured JSON via `console`, and keeps the same log event shape.
+Use the dedicated browser entry for frontend apps (Vue, React, etc.). It is a structured `console` replacement with the same call style as the server logger, without server deployment env injection.
 
 ```ts
 import logger from '@frytg/logger/browser';
-```
 
-The default `@frytg/logger` entry is server-only and will not bundle for browser targets.
-
-```ts
-logger.log({
-  level: 'alert',
-  message: 'my log message',
-  source: 'folder-a/file-b/function-c',
-  data: { name: 'my-data' },
+logger.info('user signed in', {
+  source: 'components/LoginForm',
+  data: { method: 'oauth' },
 });
 ```
 
+In development builds (`import.meta.env.DEV` or `import.meta.env.MODE === 'development'`), debug logs are enabled and output is pretty-printed JSON. Production builds log `info` and above as compact JSON.
+
+The default `@frytg/logger` entry is server-only and will not bundle for browser targets.
+
 ## Configuration
 
-The logger accesses and injects several env variables to each log event (envs listed in order of priority):
+### Server
+
+The server logger accesses and injects several env variables to each log event (envs listed in order of priority):
 
 - `host` - the host name (e.g. `my-function`)
   - from env `K_REVISION` - set by Knative such as Google Cloud Run
@@ -76,6 +76,11 @@ Additionally these environment variables are triggering different logging format
 
 - `IS_LOCAL` - set to `true` to use a more human readable, colorized output format that uses multiple lines
 - `STAGE` - set to `dev` to enable debug logs
+
+### Browser
+
+- `import.meta.env.DEV` - Vite development builds enable debug logs and pretty-printed output
+- `import.meta.env.MODE` - `development` also enables debug logs and pretty-printed output
 
 ## Log Levels
 

--- a/logger/README.md
+++ b/logger/README.md
@@ -15,9 +15,21 @@ Debug logs will only be logged if the env `STAGE` is set to `dev`.
 
 ## Usage
 
+### Server (Node.js, Deno, Bun)
+
 ```ts
 import logger from '@frytg/logger';
 ```
+
+### Browser
+
+Use the dedicated browser entry. It avoids Node built-ins and Winston, outputs structured JSON via `console`, and keeps the same log event shape.
+
+```ts
+import logger from '@frytg/logger/browser';
+```
+
+The default `@frytg/logger` entry is server-only and will not bundle for browser targets.
 
 ```ts
 logger.log({

--- a/logger/deno.jsonc
+++ b/logger/deno.jsonc
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://jsr.io/schema/config-file.v1.json",
 	"name": "@frytg/logger",
-	"version": "0.0.5",
+	"version": "0.0.6",
 	"exports": {
 		".": "./logger.ts",
 		"./browser": "./logger-browser.ts"

--- a/logger/deno.jsonc
+++ b/logger/deno.jsonc
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://jsr.io/schema/config-file.v1.json",
 	"name": "@frytg/logger",
-	"version": "0.0.7",
+	"version": "0.1.0",
 	"exports": {
 		".": "./logger.ts",
 		"./browser": "./logger-browser.ts"

--- a/logger/deno.jsonc
+++ b/logger/deno.jsonc
@@ -1,8 +1,11 @@
 {
 	"$schema": "https://jsr.io/schema/config-file.v1.json",
 	"name": "@frytg/logger",
-	"version": "0.0.4",
-	"exports": "./logger.ts",
+	"version": "0.0.5",
+	"exports": {
+		".": "./logger.ts",
+		"./browser": "./logger-browser.ts"
+	},
 	"imports": {
 		"winston": "npm:winston@^3.19.0"
 	},

--- a/logger/deno.jsonc
+++ b/logger/deno.jsonc
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://jsr.io/schema/config-file.v1.json",
 	"name": "@frytg/logger",
-	"version": "0.0.6",
+	"version": "0.0.7",
 	"exports": {
 		".": "./logger.ts",
 		"./browser": "./logger-browser.ts"

--- a/logger/logger-browser.test.ts
+++ b/logger/logger-browser.test.ts
@@ -2,25 +2,9 @@ import { test } from '@cross/test'
 import { assertEquals, assertExists } from '@std/assert'
 import sinon from 'sinon'
 
-import { detectBrowserRuntime, logger } from './logger-browser.ts'
+import { logger } from './logger-browser.ts'
 
-test('detectBrowserRuntime - returns the same value on repeated calls', () => {
-	const first = detectBrowserRuntime()
-	const second = detectBrowserRuntime()
-
-	assertEquals(second, first)
-})
-
-test('logger browser - includes global context in log events', () => {
-	const globalScope = globalThis as { __ENV__?: Record<string, string> }
-	const previousEnv = globalScope.__ENV__
-	globalScope.__ENV__ = {
-		K_REVISION: 'test-revision',
-		SERVICE_NAME: 'test-service',
-		STAGE: 'test',
-		npm_package_version: '1.0.0',
-	}
-
+test('logger browser - logs structured event fields', () => {
 	const consoleStub = sinon.stub(console, 'log')
 	let loggedOutput = ''
 	consoleStub.callsFake((output: string) => {
@@ -33,18 +17,13 @@ test('logger browser - includes global context in log events', () => {
 	})
 
 	const loggedData = JSON.parse(loggedOutput)
-	assertEquals(loggedData.host, 'test-revision')
-	assertEquals(loggedData.serviceName, 'test-service')
-	assertEquals(loggedData.stage, 'test')
-	assertEquals(loggedData.version, '1.0.0')
-	assertExists(loggedData.runtime)
+	assertEquals(loggedData.message, 'test message')
+	assertEquals(loggedData.level, 'info')
+	assertEquals(loggedData.source, 'test-source')
+	assertEquals(loggedData.data, { test: 'data' })
+	assertEquals(loggedData.host, undefined)
 
 	consoleStub.restore()
-	if (previousEnv === undefined) {
-		delete globalScope.__ENV__
-	} else {
-		globalScope.__ENV__ = previousEnv
-	}
 })
 
 test('logger browser - formats errors correctly', () => {
@@ -64,7 +43,6 @@ test('logger browser - formats errors correctly', () => {
 	assertExists(loggedData.error.message)
 	assertExists(loggedData.error.stack)
 	assertEquals(loggedData.error.message, 'test error')
-	assertExists(loggedData.runtime)
 
 	consoleStub.restore()
 })
@@ -84,9 +62,8 @@ test('logger browser - has correct syslog levels', () => {
 	assertEquals(logger.levels, expectedLevels)
 })
 
-test('logger browser - sets debug level from environment', () => {
-	const stage = (globalThis as { __ENV__?: Record<string, string> }).__ENV__?.STAGE
-	assertEquals(logger.level, stage === 'dev' ? 'debug' : 'info')
+test('logger browser - sets debug level in development builds', () => {
+	assertEquals(logger.level, isDevBuild() ? 'debug' : 'info')
 })
 
 test('logger browser - does not log below configured level', () => {
@@ -98,3 +75,15 @@ test('logger browser - does not log below configured level', () => {
 	assertEquals(consoleStub.called, false)
 	consoleStub.restore()
 })
+
+/**
+ * Mirror the browser logger development-mode check for assertions.
+ *
+ * @returns {boolean} True when the current build is development.
+ */
+const isDevBuild = (): boolean => {
+	const metaEnv = (import.meta as ImportMeta & { env?: Record<string, string | boolean | undefined> }).env
+	if (metaEnv?.DEV === true) return true
+	if (metaEnv?.MODE === 'development') return true
+	return false
+}

--- a/logger/logger-browser.test.ts
+++ b/logger/logger-browser.test.ts
@@ -1,0 +1,100 @@
+import { test } from '@cross/test'
+import { assertEquals, assertExists } from '@std/assert'
+import sinon from 'sinon'
+
+import { detectBrowserRuntime, logger } from './logger-browser.ts'
+
+test('detectBrowserRuntime - returns the same value on repeated calls', () => {
+	const first = detectBrowserRuntime()
+	const second = detectBrowserRuntime()
+
+	assertEquals(second, first)
+})
+
+test('logger browser - includes global context in log events', () => {
+	const globalScope = globalThis as { __ENV__?: Record<string, string> }
+	const previousEnv = globalScope.__ENV__
+	globalScope.__ENV__ = {
+		K_REVISION: 'test-revision',
+		SERVICE_NAME: 'test-service',
+		STAGE: 'test',
+		npm_package_version: '1.0.0',
+	}
+
+	const consoleStub = sinon.stub(console, 'log')
+	let loggedOutput = ''
+	consoleStub.callsFake((output: string) => {
+		loggedOutput = output
+	})
+
+	logger.info('test message', {
+		source: 'test-source',
+		data: { test: 'data' },
+	})
+
+	const loggedData = JSON.parse(loggedOutput)
+	assertEquals(loggedData.host, 'test-revision')
+	assertEquals(loggedData.serviceName, 'test-service')
+	assertEquals(loggedData.stage, 'test')
+	assertEquals(loggedData.version, '1.0.0')
+	assertExists(loggedData.runtime)
+
+	consoleStub.restore()
+	if (previousEnv === undefined) {
+		delete globalScope.__ENV__
+	} else {
+		globalScope.__ENV__ = previousEnv
+	}
+})
+
+test('logger browser - formats errors correctly', () => {
+	const testError = new Error('test error')
+	const consoleStub = sinon.stub(console, 'error')
+	let loggedOutput = ''
+	consoleStub.callsFake((output: string) => {
+		loggedOutput = output
+	})
+
+	logger.error('error occurred', {
+		source: 'test-source',
+		error: testError,
+	})
+
+	const loggedData = JSON.parse(loggedOutput)
+	assertExists(loggedData.error.message)
+	assertExists(loggedData.error.stack)
+	assertEquals(loggedData.error.message, 'test error')
+	assertExists(loggedData.runtime)
+
+	consoleStub.restore()
+})
+
+test('logger browser - has correct syslog levels', () => {
+	const expectedLevels = {
+		emerg: 0,
+		alert: 1,
+		crit: 2,
+		error: 3,
+		warning: 4,
+		notice: 5,
+		info: 6,
+		debug: 7,
+	}
+
+	assertEquals(logger.levels, expectedLevels)
+})
+
+test('logger browser - sets debug level from environment', () => {
+	const stage = (globalThis as { __ENV__?: Record<string, string> }).__ENV__?.STAGE
+	assertEquals(logger.level, stage === 'dev' ? 'debug' : 'info')
+})
+
+test('logger browser - does not log below configured level', () => {
+	if (logger.level === 'debug') return
+
+	const consoleStub = sinon.stub(console, 'debug')
+	logger.debug('should not log', { source: 'test-source' })
+
+	assertEquals(consoleStub.called, false)
+	consoleStub.restore()
+})

--- a/logger/logger-browser.ts
+++ b/logger/logger-browser.ts
@@ -1,0 +1,220 @@
+// deno-lint-ignore-file no-console
+/**
+ * @module
+ * A browser-safe logger with the same log event shape as `@frytg/logger`.
+ */
+
+const SYSLOG_LEVELS = {
+	emerg: 0,
+	alert: 1,
+	crit: 2,
+	error: 3,
+	warning: 4,
+	notice: 5,
+	info: 6,
+	debug: 7,
+} as const
+
+type SyslogLevel = keyof typeof SYSLOG_LEVELS
+
+type LogMetadata = {
+	source?: string
+	data?: Record<string, unknown>
+	error?: unknown
+	[key: string]: unknown
+}
+
+type LogEvent = LogMetadata & {
+	level: SyslogLevel
+	message: string
+	host: string | null
+	serviceName: string | null
+	stage: string | null
+	version: string | null
+	region: string | null
+	runtime: string
+	error?: {
+		message: string
+		stack?: string
+		[key: string]: unknown
+	}
+}
+
+type ImportMetaEnv = Record<string, string | boolean | undefined>
+
+type BrowserLogger = {
+	level: SyslogLevel
+	levels: typeof SYSLOG_LEVELS
+	log: (event: LogMetadata & { level: SyslogLevel; message: string }) => void
+} & Record<SyslogLevel, (message: string, meta?: LogMetadata) => void>
+
+let cachedBrowserRuntime: string | undefined
+
+/**
+ * Read a configuration value from browser-safe environment sources.
+ *
+ * @param {string} key - Environment variable name.
+ * @returns {string | undefined} The value when present.
+ */
+const readEnv = (key: string): string | undefined => {
+	const metaEnv = (import.meta as ImportMeta & { env?: ImportMetaEnv }).env
+	const metaValue = metaEnv?.[key]
+	if (typeof metaValue === 'string' && metaValue !== '') return metaValue
+
+	const globalEnv = (globalThis as { __ENV__?: Record<string, string> }).__ENV__
+	const globalValue = globalEnv?.[key]
+	if (globalValue !== undefined && globalValue !== '') return globalValue
+
+	return undefined
+}
+
+/**
+ * Detect and return the browser runtime label.
+ *
+ * @returns {string} A browser runtime identifier.
+ */
+export const detectBrowserRuntime = (): string => {
+	if (cachedBrowserRuntime !== undefined) return cachedBrowserRuntime
+
+	if (typeof navigator !== 'undefined' && navigator.userAgent) {
+		cachedBrowserRuntime = `browser-${navigator.userAgent}`
+	} else {
+		cachedBrowserRuntime = 'browser-unknown'
+	}
+
+	return cachedBrowserRuntime
+}
+
+/**
+ * Resolve the minimum log level from environment configuration.
+ *
+ * @returns {SyslogLevel} The configured minimum log level.
+ */
+const resolveMinLevel = (): SyslogLevel => {
+	const stage = readEnv('STAGE') ?? readEnv('NODE_ENV') ?? readEnv('MODE') ?? readEnv('VITE_STAGE')
+	return stage === 'dev' ? 'debug' : 'info'
+}
+
+/**
+ * Determine whether local, colorized output should be used.
+ *
+ * @returns {boolean} True when local output is enabled.
+ */
+const isLocalOutput = (): boolean => readEnv('IS_LOCAL') === 'true' || readEnv('DEV') === 'true'
+
+/**
+ * Serialize an error for structured logging.
+ *
+ * @param {unknown} error - The error value to serialize.
+ * @returns {LogEvent['error'] | undefined} Serialized error fields.
+ */
+const serializeError = (error: unknown): LogEvent['error'] | undefined => {
+	if (!(error instanceof Error)) return undefined
+
+	return {
+		...error,
+		message: error.message,
+		stack: error.stack,
+	}
+}
+
+/**
+ * Build global context fields injected into each log event.
+ *
+ * @returns {Omit<LogEvent, 'level' | 'message'>} Global log context.
+ */
+const buildGlobalContext = (): Omit<LogEvent, 'level' | 'message'> => ({
+	host: readEnv('K_REVISION') ??
+		readEnv('HOST') ??
+		(typeof globalThis.location !== 'undefined' ? globalThis.location.hostname : null),
+	serviceName: readEnv('SERVICE_NAME') ?? readEnv('K_SERVICE') ?? readEnv('VITE_SERVICE_NAME') ?? null,
+	stage: readEnv('STAGE') ?? readEnv('NODE_ENV') ?? readEnv('MODE') ?? readEnv('VITE_STAGE') ?? null,
+	version: readEnv('SERVICE_VERSION') ?? readEnv('npm_package_version') ?? readEnv('VITE_SERVICE_VERSION') ??
+		null,
+	region: readEnv('REGION') ?? readEnv('AWS_REGION') ?? readEnv('FLY_REGION') ?? readEnv('DENO_REGION') ??
+		null,
+	runtime: detectBrowserRuntime(),
+})
+
+/**
+ * Determine whether a log event should be emitted for the configured level.
+ *
+ * @param {SyslogLevel} eventLevel - The event severity.
+ * @param {SyslogLevel} configuredLevel - The configured minimum level.
+ * @returns {boolean} True when the event should be logged.
+ */
+const shouldLog = (eventLevel: SyslogLevel, configuredLevel: SyslogLevel): boolean =>
+	SYSLOG_LEVELS[eventLevel] <= SYSLOG_LEVELS[configuredLevel]
+
+/**
+ * Select the console method that best matches a syslog level.
+ *
+ * @param {SyslogLevel} level - The syslog level.
+ * @returns {'debug' | 'error' | 'log' | 'warn'} The console method to use.
+ */
+const consoleMethodForLevel = (level: SyslogLevel): 'debug' | 'error' | 'log' | 'warn' => {
+	if (level === 'error' || level === 'crit' || level === 'emerg' || level === 'alert') return 'error'
+	if (level === 'warning') return 'warn'
+	if (level === 'debug') return 'debug'
+	return 'log'
+}
+
+/**
+ * Format a log event for output.
+ *
+ * @param {LogEvent} event - The structured log event.
+ * @returns {string} Serialized log output.
+ */
+const formatLogEvent = (event: LogEvent): string =>
+	isLocalOutput() ? JSON.stringify(event, null, 4) : JSON.stringify(event)
+
+/**
+ * Create a browser-safe logger with syslog levels and structured JSON output.
+ *
+ * @returns {BrowserLogger} Configured browser logger.
+ */
+const createBrowserLogger = (): BrowserLogger => {
+	const logger: BrowserLogger = {
+		level: resolveMinLevel(),
+		levels: SYSLOG_LEVELS,
+		log: (event) => {
+			if (!shouldLog(event.level, logger.level)) return
+
+			const serializedError = serializeError(event.error)
+			const logEvent: LogEvent = {
+				...buildGlobalContext(),
+				...event,
+				...(serializedError ? { error: serializedError } : {}),
+			}
+
+			console[consoleMethodForLevel(event.level)](formatLogEvent(logEvent))
+		},
+	} as BrowserLogger
+
+	for (const level of Object.keys(SYSLOG_LEVELS) as SyslogLevel[]) {
+		logger[level] = (message: string, meta: LogMetadata = {}) => {
+			logger.log({ level, message, ...meta })
+		}
+	}
+
+	return logger
+}
+
+/**
+ * Use the exported logger to log messages in browser environments.
+ *
+ * @example basic log
+ * ```ts
+ * import logger from '@frytg/logger/browser'
+ *
+ * logger.log({
+ *   level: 'debug',
+ *   message: 'my log message',
+ *   source: 'folder-a/file-b/function-c',
+ *   data: { name: 'my-data' },
+ * })
+ * ```
+ */
+export const logger = createBrowserLogger()
+
+export default logger

--- a/logger/logger-browser.ts
+++ b/logger/logger-browser.ts
@@ -1,7 +1,7 @@
 // deno-lint-ignore-file no-console
 /**
  * @module
- * A browser-safe logger with the same log event shape as `@frytg/logger`.
+ * A browser-safe structured console logger for frontend apps.
  */
 
 const SYSLOG_LEVELS = {
@@ -24,16 +24,7 @@ type LogMetadata = {
 	[key: string]: unknown
 }
 
-type GlobalContext = {
-	host: string | null
-	serviceName: string | null
-	stage: string | null
-	version: string | null
-	region: string | null
-	runtime: string
-}
-
-type LogEvent = LogMetadata & GlobalContext & {
+type LogEvent = LogMetadata & {
 	level: SyslogLevel
 	message: string
 	error?: {
@@ -51,59 +42,24 @@ type BrowserLogger = {
 	log: (event: LogMetadata & { level: SyslogLevel; message: string }) => void
 } & Record<SyslogLevel, (message: string, meta?: LogMetadata) => void>
 
-let cachedBrowserRuntime: string | undefined
-
 /**
- * Read a configuration value from browser-safe environment sources.
+ * Determine whether the app is running in development mode.
  *
- * @param {string} key - Environment variable name.
- * @returns {string | undefined} The value when present.
+ * @returns {boolean} True when running in a development build.
  */
-const readEnv = (key: string): string | undefined => {
+const isDev = (): boolean => {
 	const metaEnv = (import.meta as ImportMeta & { env?: ImportMetaEnv }).env
-	const metaValue = metaEnv?.[key]
-	if (typeof metaValue === 'string' && metaValue !== '') return metaValue
-
-	const globalEnv = (globalThis as { __ENV__?: Record<string, string> }).__ENV__
-	const globalValue = globalEnv?.[key]
-	if (globalValue !== undefined && globalValue !== '') return globalValue
-
-	return undefined
+	if (metaEnv?.DEV === true) return true
+	if (metaEnv?.MODE === 'development') return true
+	return false
 }
 
 /**
- * Detect and return the browser runtime label.
- *
- * @returns {string} A browser runtime identifier.
- */
-export const detectBrowserRuntime = (): string => {
-	if (cachedBrowserRuntime !== undefined) return cachedBrowserRuntime
-
-	if (typeof navigator !== 'undefined' && navigator.userAgent) {
-		cachedBrowserRuntime = `browser-${navigator.userAgent}`
-	} else {
-		cachedBrowserRuntime = 'browser-unknown'
-	}
-
-	return cachedBrowserRuntime
-}
-
-/**
- * Resolve the minimum log level from environment configuration.
+ * Resolve the minimum log level for the current build.
  *
  * @returns {SyslogLevel} The configured minimum log level.
  */
-const resolveMinLevel = (): SyslogLevel => {
-	const stage = readEnv('STAGE') ?? readEnv('NODE_ENV') ?? readEnv('MODE') ?? readEnv('VITE_STAGE')
-	return stage === 'dev' ? 'debug' : 'info'
-}
-
-/**
- * Determine whether local, colorized output should be used.
- *
- * @returns {boolean} True when local output is enabled.
- */
-const isLocalOutput = (): boolean => readEnv('IS_LOCAL') === 'true' || readEnv('DEV') === 'true'
+const resolveMinLevel = (): SyslogLevel => isDev() ? 'debug' : 'info'
 
 /**
  * Serialize an error for structured logging.
@@ -120,24 +76,6 @@ const serializeError = (error: unknown): LogEvent['error'] | undefined => {
 		...(error.stack !== undefined ? { stack: error.stack } : {}),
 	}
 }
-
-/**
- * Build global context fields injected into each log event.
- *
- * @returns {GlobalContext} Global log context.
- */
-const buildGlobalContext = (): GlobalContext => ({
-	host: readEnv('K_REVISION') ??
-		readEnv('HOST') ??
-		(typeof globalThis.location !== 'undefined' ? globalThis.location.hostname : null),
-	serviceName: readEnv('SERVICE_NAME') ?? readEnv('K_SERVICE') ?? readEnv('VITE_SERVICE_NAME') ?? null,
-	stage: readEnv('STAGE') ?? readEnv('NODE_ENV') ?? readEnv('MODE') ?? readEnv('VITE_STAGE') ?? null,
-	version: readEnv('SERVICE_VERSION') ?? readEnv('npm_package_version') ?? readEnv('VITE_SERVICE_VERSION') ??
-		null,
-	region: readEnv('REGION') ?? readEnv('AWS_REGION') ?? readEnv('FLY_REGION') ?? readEnv('DENO_REGION') ??
-		null,
-	runtime: detectBrowserRuntime(),
-})
 
 /**
  * Determine whether a log event should be emitted for the configured level.
@@ -163,13 +101,12 @@ const consoleMethodForLevel = (level: SyslogLevel): 'debug' | 'error' | 'log' | 
 }
 
 /**
- * Format a log event for output.
+ * Format a log event for console output.
  *
  * @param {LogEvent} event - The structured log event.
  * @returns {string} Serialized log output.
  */
-const formatLogEvent = (event: LogEvent): string =>
-	isLocalOutput() ? JSON.stringify(event, null, 4) : JSON.stringify(event)
+const formatLogEvent = (event: LogEvent): string => isDev() ? JSON.stringify(event, null, 4) : JSON.stringify(event)
 
 /**
  * Create a browser-safe logger with syslog levels and structured JSON output.
@@ -185,7 +122,6 @@ const createBrowserLogger = (): BrowserLogger => {
 
 			const serializedError = serializeError(event.error)
 			const logEvent: LogEvent = {
-				...buildGlobalContext(),
 				level: event.level,
 				message: event.message,
 				...(event.source !== undefined ? { source: event.source } : {}),
@@ -213,11 +149,9 @@ const createBrowserLogger = (): BrowserLogger => {
  * ```ts
  * import logger from '@frytg/logger/browser'
  *
- * logger.log({
- *   level: 'debug',
- *   message: 'my log message',
- *   source: 'folder-a/file-b/function-c',
- *   data: { name: 'my-data' },
+ * logger.info('my log message', {
+ *   source: 'components/MyComponent',
+ *   data: { userId: '123' },
  * })
  * ```
  */

--- a/logger/logger-browser.ts
+++ b/logger/logger-browser.ts
@@ -4,18 +4,8 @@
  * A browser-safe structured console logger for frontend apps.
  */
 
-const SYSLOG_LEVELS = {
-	emerg: 0,
-	alert: 1,
-	crit: 2,
-	error: 3,
-	warning: 4,
-	notice: 5,
-	info: 6,
-	debug: 7,
-} as const
-
-type SyslogLevel = keyof typeof SYSLOG_LEVELS
+import { type SerializedError, serializeError } from './serialize-error.ts'
+import { shouldLog, SYSLOG_LEVELS, type SyslogLevel } from './syslog-levels.ts'
 
 type LogMetadata = {
 	source?: string
@@ -27,11 +17,7 @@ type LogMetadata = {
 type LogEvent = LogMetadata & {
 	level: SyslogLevel
 	message: string
-	error?: {
-		message: string
-		stack?: string
-		[key: string]: unknown
-	}
+	error?: SerializedError
 }
 
 type ImportMetaEnv = Record<string, string | boolean | undefined>
@@ -60,32 +46,6 @@ const isDev = (): boolean => {
  * @returns {SyslogLevel} The configured minimum log level.
  */
 const resolveMinLevel = (): SyslogLevel => isDev() ? 'debug' : 'info'
-
-/**
- * Serialize an error for structured logging.
- *
- * @param {unknown} error - The error value to serialize.
- * @returns {LogEvent['error'] | undefined} Serialized error fields.
- */
-const serializeError = (error: unknown): LogEvent['error'] | undefined => {
-	if (!(error instanceof Error)) return undefined
-
-	return {
-		...error,
-		message: error.message,
-		...(error.stack !== undefined ? { stack: error.stack } : {}),
-	}
-}
-
-/**
- * Determine whether a log event should be emitted for the configured level.
- *
- * @param {SyslogLevel} eventLevel - The event severity.
- * @param {SyslogLevel} configuredLevel - The configured minimum level.
- * @returns {boolean} True when the event should be logged.
- */
-const shouldLog = (eventLevel: SyslogLevel, configuredLevel: SyslogLevel): boolean =>
-	SYSLOG_LEVELS[eventLevel] <= SYSLOG_LEVELS[configuredLevel]
 
 /**
  * Select the console method that best matches a syslog level.

--- a/logger/logger-browser.ts
+++ b/logger/logger-browser.ts
@@ -24,15 +24,18 @@ type LogMetadata = {
 	[key: string]: unknown
 }
 
-type LogEvent = LogMetadata & {
-	level: SyslogLevel
-	message: string
+type GlobalContext = {
 	host: string | null
 	serviceName: string | null
 	stage: string | null
 	version: string | null
 	region: string | null
 	runtime: string
+}
+
+type LogEvent = LogMetadata & GlobalContext & {
+	level: SyslogLevel
+	message: string
 	error?: {
 		message: string
 		stack?: string
@@ -114,16 +117,16 @@ const serializeError = (error: unknown): LogEvent['error'] | undefined => {
 	return {
 		...error,
 		message: error.message,
-		stack: error.stack,
+		...(error.stack !== undefined ? { stack: error.stack } : {}),
 	}
 }
 
 /**
  * Build global context fields injected into each log event.
  *
- * @returns {Omit<LogEvent, 'level' | 'message'>} Global log context.
+ * @returns {GlobalContext} Global log context.
  */
-const buildGlobalContext = (): Omit<LogEvent, 'level' | 'message'> => ({
+const buildGlobalContext = (): GlobalContext => ({
 	host: readEnv('K_REVISION') ??
 		readEnv('HOST') ??
 		(typeof globalThis.location !== 'undefined' ? globalThis.location.hostname : null),
@@ -183,8 +186,11 @@ const createBrowserLogger = (): BrowserLogger => {
 			const serializedError = serializeError(event.error)
 			const logEvent: LogEvent = {
 				...buildGlobalContext(),
-				...event,
-				...(serializedError ? { error: serializedError } : {}),
+				level: event.level,
+				message: event.message,
+				...(event.source !== undefined ? { source: event.source } : {}),
+				...(event.data !== undefined ? { data: event.data } : {}),
+				...(serializedError !== undefined ? { error: serializedError } : {}),
 			}
 
 			console[consoleMethodForLevel(event.level)](formatLogEvent(logEvent))

--- a/logger/logger-browser.ts
+++ b/logger/logger-browser.ts
@@ -215,6 +215,6 @@ const createBrowserLogger = (): BrowserLogger => {
  * })
  * ```
  */
-export const logger = createBrowserLogger()
+export const logger: BrowserLogger = createBrowserLogger()
 
 export default logger

--- a/logger/logger.ts
+++ b/logger/logger.ts
@@ -7,19 +7,19 @@
 import os from 'node:os'
 import process from 'node:process'
 import type { Logform, Logger } from 'winston'
-import { config, createLogger, format, transports } from 'winston'
+import { createLogger, format, transports } from 'winston'
+
+import { serializeError } from './serialize-error.ts'
+import { SYSLOG_LEVELS } from './syslog-levels.ts'
 
 // set config once
 const hostName = os.hostname()
 
 // Format error objects
 const convertError = format((event) => {
-	if (event?.error instanceof Error) {
-		event.error = {
-			...event.error,
-			message: event.error.message,
-			stack: event.error.stack,
-		}
+	const serializedError = serializeError(event?.error)
+	if (serializedError !== undefined) {
+		event.error = serializedError
 	}
 	return event
 })
@@ -115,7 +115,7 @@ const formatConfigLocal: Logform.Format = format.combine(
  */
 export const logger: Logger = createLogger({
 	level: process.env.STAGE === 'dev' ? 'debug' : 'info',
-	levels: config.syslog.levels,
+	levels: SYSLOG_LEVELS,
 	exitOnError: false,
 	format: process.env.IS_LOCAL === 'true' ? formatConfigLocal : formatConfig,
 	transports: [new transports.Console()],

--- a/logger/serialize-error.ts
+++ b/logger/serialize-error.ts
@@ -1,0 +1,26 @@
+/**
+ * @module
+ * Shared error serialization for structured log events.
+ */
+
+export type SerializedError = {
+	message: string
+	stack?: string
+	[key: string]: unknown
+}
+
+/**
+ * Serialize an error for structured logging.
+ *
+ * @param {unknown} error - The error value to serialize.
+ * @returns {SerializedError | undefined} Serialized error fields.
+ */
+export const serializeError = (error: unknown): SerializedError | undefined => {
+	if (!(error instanceof Error)) return undefined
+
+	return {
+		...error,
+		message: error.message,
+		...(error.stack !== undefined ? { stack: error.stack } : {}),
+	}
+}

--- a/logger/syslog-levels.ts
+++ b/logger/syslog-levels.ts
@@ -1,0 +1,27 @@
+/**
+ * @module
+ * Shared syslog level definitions used by server and browser loggers.
+ */
+
+export const SYSLOG_LEVELS = {
+	emerg: 0,
+	alert: 1,
+	crit: 2,
+	error: 3,
+	warning: 4,
+	notice: 5,
+	info: 6,
+	debug: 7,
+} as const
+
+export type SyslogLevel = keyof typeof SYSLOG_LEVELS
+
+/**
+ * Determine whether a log event should be emitted for the configured level.
+ *
+ * @param {SyslogLevel} eventLevel - The event severity.
+ * @param {SyslogLevel} configuredLevel - The configured minimum level.
+ * @returns {boolean} True when the event should be logged.
+ */
+export const shouldLog = (eventLevel: SyslogLevel, configuredLevel: SyslogLevel): boolean =>
+	SYSLOG_LEVELS[eventLevel] <= SYSLOG_LEVELS[configuredLevel]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Investigated whether the default `@frytg/logger` entry can be optimized for browser use. It cannot: bundling with esbuild for `--platform=browser` fails on `node:os`, `node:process`, and Winston's Node dependencies.

Adds a dedicated `@frytg/logger/browser` entry for frontend apps (Vue, React, etc.) as a structured `console` replacement:
- Avoids Node built-ins and Winston
- Logs caller-provided fields only (`level`, `message`, `source`, `data`, `error`) — no server deployment env injection
- Uses `import.meta.env.DEV` / `MODE === 'development'` for debug level and pretty-printed JSON
- Bundles to ~3.1 KB (esbuild) vs. the default entry which does not bundle at all

## Usage

```ts
// Server (unchanged)
import logger from '@frytg/logger';

// Browser
import logger from '@frytg/logger/browser';

logger.info('user signed in', {
  source: 'components/LoginForm',
  data: { method: 'oauth' },
});
```

## How to test

- `deno run test` / `npx tsx --test logger/*.test.ts` — all logger tests pass
- `npx esbuild logger/logger-browser.ts --bundle --platform=browser --format=esm --outfile=/tmp/logger-browser-bundle.js` — bundles successfully (~3.1 KB)
- `npx esbuild logger/logger.ts --bundle --platform=browser` — still fails (expected; default entry remains server-only)

## Follow-ups

- Forward browser logs to a backend endpoint in a future version
- Consider extracting shared syslog level constants if both entries need to stay in sync long-term

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c63aac08-1e1c-4005-bef3-c4a3420d8c63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c63aac08-1e1c-4005-bef3-c4a3420d8c63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

